### PR TITLE
Accept arbitrary arguments in `coh test`

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -22,7 +22,12 @@ def build():
     runpy.run_module('coherent.build', run_name='__main__')
 
 
-@app.command()
+@app.command(
+    context_settings={
+        'allow_extra_args': True,
+        'ignore_unknown_options': True,
+    },
+)
 def test():
     del sys.argv[1]
     runpy.run_module('coherent.test', run_name='__main__')


### PR DESCRIPTION
Allows to manage plugins.
Most probably fixes https://github.com/dummy-coherent-org/project/actions/runs/9832369253/job/27514794014 (we are now unable to diffcov via `coh test` in reusable workflows).
